### PR TITLE
feat: include grammar.moduleInclude

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -141,6 +141,8 @@ function generateCode(
     "\n\n" +
     yyDeclarations +
     "\n\n" +
+    (grammar.moduleInclude || '') +
+    "\n\n" +
     locationInterfaceDeclaration +
     "\n\n" +
     semanticActions

--- a/src/lib/bnf-parser.d.ts
+++ b/src/lib/bnf-parser.d.ts
@@ -3,6 +3,9 @@ export interface BnfParser {
 }
 
 export interface ParsedBnfGrammar {
+
+  moduleInclude?: string;
+
   lex?: {
     rules: [string, string][];
   };

--- a/test/__file_snapshots__/noTypeErrors/usesModuleInclude.ts
+++ b/test/__file_snapshots__/noTypeErrors/usesModuleInclude.ts
@@ -1,0 +1,28 @@
+import { TysonTypeDictionary } from "../../fixtures/shouldSucceed/usesModuleInclude/typeDict";
+
+function createNodeWithDepth(depth: number): number {
+  return depth;
+}
+
+const semanticActions = {
+  "start -> optParens EOF"(
+    $1: TysonTypeDictionary["optParens"]
+  ): TysonTypeDictionary["start"] {
+    let $$: TysonTypeDictionary["start"];
+    return $1;
+  },
+
+  "optParens -> "(): TysonTypeDictionary["optParens"] {
+    let $$: TysonTypeDictionary["optParens"];
+    $$ = createNodeWithDepth(0);
+    return $$;
+  },
+
+  "optParens -> ( optParens )"(
+    $2: TysonTypeDictionary["optParens"]
+  ): TysonTypeDictionary["optParens"] {
+    let $$: TysonTypeDictionary["optParens"];
+    $$ = createNodeWithDepth(1 + $2);
+    return $$;
+  },
+};

--- a/test/fixtures/shouldSucceed/usesModuleInclude/grammar.jison
+++ b/test/fixtures/shouldSucceed/usesModuleInclude/grammar.jison
@@ -1,0 +1,35 @@
+/* description: Parses end executes mathematical expressions. */
+
+%{
+    function createNodeWithDepth (depth:number): number {
+      return depth;
+    }
+%}
+
+/* lexical grammar */
+%lex
+%%
+
+\s+                   /* skip whitespace */
+"("                   return '('
+")"                   return ')'
+<<EOF>>               return 'EOF'
+.                     return 'INVALID'
+
+/lex
+
+%start start
+
+%% /* language grammar */
+
+start
+    : optParens EOF
+        {return $1;}
+    ;
+
+optParens
+    : %empty
+        {$$=createNodeWithDepth(0);}
+    | "(" optParens ")"
+        {$$=createNodeWithDepth(1 + $2);}
+    ;

--- a/test/fixtures/shouldSucceed/usesModuleInclude/typeDict.ts
+++ b/test/fixtures/shouldSucceed/usesModuleInclude/typeDict.ts
@@ -1,0 +1,9 @@
+export interface TysonTypeDictionary {
+  "(": string;
+  ")": string;
+  EOF: "";
+  INVALID: string;
+
+  start: number;
+  optParens: number;
+}


### PR DESCRIPTION
This includes text from the %{...%} stuff at the top of the grammar in the into the tyson-generated ts. This is nice for folks used to sticking constants into to top of the grammar. It's a bit more problematic for functions declared in the grammar 'cause they've either got to be typescript-y enough that you can tsc the jison-generated module or you have to have a wicked relaxed tsconfig when you compile the tyson-generated ts. I'll raise an issue about that.